### PR TITLE
Fixed permanent event listeners

### DIFF
--- a/angular-click-outside.js
+++ b/angular-click-outside.js
@@ -25,7 +25,7 @@ function twClickOutside ($window, $parse) {
       $window.addEventListener('click', handler, true);
 
       scope.$on('$destroy', function(e) {
-        $window.removeEventListener('click', handler);
+        $window.removeEventListener('click', handler, true);
       });
     }
   };


### PR DESCRIPTION
When calling `removeEventListener`, the `useCapture` param must match the value that the listener was added with, otherwise the handler is never removed. This issue results in the closure context staying on the heap permanently, which causes memory leaks.